### PR TITLE
feat(calendar) added new feature for displaying public holidays date …

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -1,19 +1,20 @@
-// Please add your country's public holidays here
-// Example structure: 2025: [ { day: 17, month: 8, name: "Indonesia Independence Day" }, ... ]
-// For recurring holidays every year, use the 'recurring' key
+/* 
+    Please add your country's public holidays here
+    Example structure: 
+    - 2025: [ { day: 17, month: 8, name: "Indonesia Independence Day" }, ... ]
+    - "2025": [ { day: "1", month: "1", name: "New Year's Day" }, ... ]
+
+    Note: You can use either numbers or strings for day/month/year values.
+*/
 
 var publicHoliday = {
-    2025: [
-        { day: null, month: null, name: "EXAMPLE: Your Country Public Holiday" }
+    "2025": [
+        { day: "EMPTY", month: "EMPTY", name: "EMPTY" },
+        { day: "EMPTY", month: "EMPTY", name: "EMPTY" },
+        { day: "EMPTY", month: "EMPTY", name: "EMPTY" }
     ],
-    2026: [
-        { day: null, month: null, name: "EXAMPLE: Your Country Public Holiday" },
-        { day: null, month: null, name: "EXAMPLE: Your Country Public Holiday" }
-    ],
-    // Recurring holidays every year
-    recurring: [
-        { day: 1, month: 1, name: "New Year's Day" },
-        { day: 14, month: 2, name: "Valentine's Day" },
-        { day: 25, month: 12, name: "Christmas" }
+    "2026": [
+        { day: "EMPTY", month: "EMPTY", name: "EMPTY" },
+        { day: "EMPTY", month: "EMPTY", name: "EMPTY" }
     ]
 }

--- a/calendar.js
+++ b/calendar.js
@@ -1,0 +1,19 @@
+// Please add your country's public holidays here
+// Example structure: 2025: [ { day: 17, month: 8, name: "Indonesia Independence Day" }, ... ]
+// For recurring holidays every year, use the 'recurring' key
+
+var publicHoliday = {
+    2025: [
+        { day: null, month: null, name: "EXAMPLE: Your Country Public Holiday" }
+    ],
+    2026: [
+        { day: null, month: null, name: "EXAMPLE: Your Country Public Holiday" },
+        { day: null, month: null, name: "EXAMPLE: Your Country Public Holiday" }
+    ],
+    // Recurring holidays every year
+    recurring: [
+        { day: 1, month: 1, name: "New Year's Day" },
+        { day: 14, month: 2, name: "Valentine's Day" },
+        { day: 25, month: 12, name: "Christmas" }
+    ]
+}

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 
     <script type="text/javascript" src="notes.js"></script>
     <script type="text/javascript" src="schedule.js"></script>
+    <script type="text/javascript" src="calendar.js"></script>
 
     <script type="text/javascript" src="js/widgets/date.js"></script>
     <script type="text/javascript" src="js/widgets/notes.js"></script>

--- a/js/mccw.js
+++ b/js/mccw.js
@@ -28,6 +28,14 @@ window.MCCW = {
     },
     helpers: {
         setColor: () => {},
+        // Returns current day/month/year in a consistent format for widgets and addons
+        getCurrentDateInfo: () => {
+            return {
+                currentDay: Number(MCCW.date.time && MCCW.date.time[2] ? MCCW.date.time[2] : MCCW.date.initial.getDate()),
+                currentMonth: MCCW.date.initial.getMonth(),
+                currentYear: MCCW.date.initial.getFullYear()
+            };
+        }
     },
     functions : {
         bootup: async () => {

--- a/js/widgets/calendar.js
+++ b/js/widgets/calendar.js
@@ -111,6 +111,11 @@ function collectHolidays(year){
 
 function normalizeHolidayMonth(month){
     let hm = typeof month === "number" ? Number(month) : NaN;
-    if (!isNaN(hm) && hm > 11) hm = hm - 1; // allow 1-12 input
+    // Validate month range
+    if (isNaN(hm) || hm < 1 || hm > 12) 
+        return NaN;
+    // Convert 1-12 to 0-11, because Date.getMonth() is zero-based
+    if (hm >= 1 && hm <= 12) 
+        hm = hm - 1;
     return hm;
 }

--- a/js/widgets/calendar.js
+++ b/js/widgets/calendar.js
@@ -3,12 +3,15 @@ var calendar_widget = {
     fill: fillWidgetCalendar
 };
 
+var calendarCells = [];
+
 function drawWidgetCalendar(){
     document.getElementById("calendar").innerHTML = "<tr><th>SU</th><th>MO</th><th>TU</th><th>WE</th><th>TH</th><th>FR</th><th>SA</th></tr>";
 
     let month = MCCW.date.initial.getMonth();
     let year = MCCW.date.initial.getFullYear();
     let days = new Date(year, month + 1, 0).getDate();
+    calendarCells = [];
     let elem = document.createElement("tr");
     let auxiliary = new Date(year, month, 1).getDay();
 
@@ -28,38 +31,29 @@ function drawWidgetCalendar(){
     };
 
     function loadCell(data){
-        // create td and attach dataset info so we can recognise today/holidays later
-        let td = document.createElement("td");
-        if (data !== ""){
-            td.dataset.day = data;
-            td.dataset.month = month; // zero-based month to match Date.getMonth()
-            td.dataset.year = year;
-            td.appendChild(document.createTextNode(data));
-        } else {
-            td.appendChild(document.createTextNode(""));
-        }
+        const td = document.createElement("td");
+        const dayVal = data !== "" ? Number(data) : null;
+        td.textContent = data;
         elem.appendChild(td);
-    };
+        calendarCells.push({ td, day: dayVal, month, year });
+    }
 
     document.getElementById("calendar").appendChild(elem);
 }
 
 
 function fillWidgetCalendar(){
-    const { currentDay, currentMonth, currentYear } = getCurrentDateInfo();
+    const { currentDay, currentMonth, currentYear } = MCCW.helpers.getCurrentDateInfo();
     let pastDayFlag = true; // Past day flag
-    const days = document.getElementById("calendar").getElementsByTagName("td");
     const holidays = collectHolidays(currentYear);
 
-    for (let i = 0; i < days.length; i++){
-        const td = days[i];
-        const dStr = td.dataset.day;
-        if (!dStr){ // skip empty leading/trailing cells
-            continue;
-        }
-        const d = Number(dStr);
-        const m = Number(td.dataset.month);
-        const y = Number(td.dataset.year);
+    for (let i = 0; i < calendarCells.length; i++){
+        const cell = calendarCells[i];
+        const td = cell.td;
+        const d = cell.day;
+        if (d === null) continue; // skip empty leading/trailing cells
+        const m = cell.month;
+        const y = cell.year;
 
         if (pastDayFlag){
             td.classList.add("past"); // Add past day class
@@ -74,48 +68,116 @@ function fillWidgetCalendar(){
     }
 }
 
-function findHolidayForDay(holidays, day, month, year){
-    for (let h of holidays){
-        const hd = Number(h.day);
-        const hm = normalizeHolidayMonth(h.month);
-        const hy = h.year ? Number(h.year) : undefined;
-
-        if (hd === day && hm === month && (hy === undefined || hy === year)){
-            return h;
+function findHolidayForDay(holidaysByMonth, day, month, year){
+    // holidaysByMonth is expected to be an array of 12 objects mapping day->holiday or day->array of holidays
+    if (!Array.isArray(holidaysByMonth) || holidaysByMonth.length !== 12) return null;
+    const monthMap = holidaysByMonth[month];
+    if (!monthMap) return null;
+    const entry = monthMap[day];
+    if (!entry) return null;
+    if (Array.isArray(entry)){
+        // prefer a holiday that explicitly matches the year if available
+        for (let h of entry){
+            const hy = h.year ? Number(h.year) : undefined;
+            if (hy === undefined || hy === year) return h;
         }
+        return entry[0];
     }
-    return null;
+    return entry;
 }
 
 function applyHolidayToTd(td, h){
     td.classList.add("holiday");
-    if (h.name) td.dataset.tooltip = h.name;  // used by custom CSS tooltip
+    if (h.name){
+        const tip = document.createElement('span');
+        tip.className = 'holiday-tooltip';
+        tip.textContent = h.name;
+        td.appendChild(tip);
+    }
 }
 
-function getCurrentDateInfo(){
-    return {
-        currentDay: Number(MCCW.date.time && MCCW.date.time[2] ? MCCW.date.time[2] : MCCW.date.initial.getDate()),
-        currentMonth: MCCW.date.initial.getMonth(),
-        currentYear: MCCW.date.initial.getFullYear()
-    };
-}
+
 
 function collectHolidays(year){
-    let holidays = [];
-    if (typeof publicHoliday === "object" && publicHoliday !== null){
-        if (Array.isArray(publicHoliday[year])) holidays = holidays.concat(publicHoliday[year]);
-        if (Array.isArray(publicHoliday.recurring)) holidays = holidays.concat(publicHoliday.recurring);
+    // If the user disabled public holidays in properties, return empty mapping
+    if (MCCW.properties && MCCW.properties.calendar && MCCW.properties.calendar.showHolidays === false){
+        return Array.from({length: 12}, () => ({}));
     }
-    return holidays;
+
+    // Build a month-indexed lookup: array of 12 objects mapping day -> holiday or day -> [holidays]
+    const holidaysByMonth = Array.from({length: 12}, () => ({}));
+    if (typeof publicHoliday === "object" && publicHoliday !== null){
+        const list = Array.isArray(publicHoliday[year]) ? publicHoliday[year] : [];
+        for (let h of list){
+            // Normalize fields (accept numbers or numeric strings and return integers)
+            const normalized = normalizeHoliday(h);
+            const hm = normalized.month;
+            const hd = normalized.day;
+            const hy = normalized.year;
+
+            // Validate normalized month and day range (month 0-11, day 1-31)
+            if (!Number.isInteger(hm) || hm < 0 || hm > 11 || !Number.isInteger(hd) || hd < 1 || hd > 31) 
+                continue;
+            if (hy !== undefined && hy !== year) continue; // skip holidays for different years
+
+            // if month/day valid, add to mapping
+            if (!holidaysByMonth[hm][hd]) 
+                holidaysByMonth[hm][hd] = h;
+            else { // else already exists, convert to array or append
+                if (!Array.isArray(holidaysByMonth[hm][hd])) 
+                    holidaysByMonth[hm][hd] = [holidaysByMonth[hm][hd]];
+                
+                // Append holiday
+                holidaysByMonth[hm][hd].push(h);
+            }
+        }
+    }
+    return holidaysByMonth;
 }
 
-function normalizeHolidayMonth(month){
-    let hm = typeof month === "number" ? Number(month) : NaN;
-    // Validate month range
-    if (isNaN(hm) || hm < 1 || hm > 12) 
-        return NaN;
-    // Convert 1-12 to 0-11, because Date.getMonth() is zero-based
-    if (hm >= 1 && hm <= 12) 
-        hm = hm - 1;
-    return hm;
+function normalizeHoliday(h){
+    // Accept numbers or numeric strings and return normalized integers:
+    const result = { month: undefined, day: undefined, year: undefined };
+
+    // Month
+    if (h.month !== undefined && h.month !== null && h.month !== ''){
+        let m = h.month;
+        if (typeof m === 'string'){
+            if (m.trim() === '') { 
+                result.month = undefined;
+            }
+            else m = Number(m);
+        }
+
+        if (m >= 1 && m <= 12)
+            result.month = m - 1;
+        else 
+            result.month = m;
+    }
+
+    // Day
+    if (h.day !== undefined && h.day !== null && h.day !== ''){
+        let d = h.day;
+        if (typeof d === 'string'){
+            if (d.trim() === '') { 
+                result.day = undefined;
+            }
+            else d = Number(d);
+        }
+        result.day = d;
+    }
+
+    // Year
+    if (h.year !== undefined && h.year !== null && h.year !== ''){
+        let y = h.year;
+        if (typeof y === 'string'){
+            if (y.trim() === '') {
+                result.year = undefined; 
+            }
+            else y = Number(y);
+        }
+        result.year = y;
+    }
+
+    return result;
 }

--- a/js/widgets/calendar.js
+++ b/js/widgets/calendar.js
@@ -7,16 +7,17 @@ function drawWidgetCalendar(){
     document.getElementById("calendar").innerHTML = "<tr><th>SU</th><th>MO</th><th>TU</th><th>WE</th><th>TH</th><th>FR</th><th>SA</th></tr>";
 
     let month = MCCW.date.initial.getMonth();
-    let days = new Date(MCCW.date.initial.getFullYear(), month + 1, 0).getDate();
+    let year = MCCW.date.initial.getFullYear();
+    let days = new Date(year, month + 1, 0).getDate();
     let elem = document.createElement("tr");
-    let auxiliary = new Date(MCCW.date.initial.getFullYear(), month, 1).getDay();
+    let auxiliary = new Date(year, month, 1).getDay();
 
     for (let i = 0; i < auxiliary; i++){
         loadCell("");
     };
 
     for (let i = 1; i <= days; i++){
-        auxiliary = new Date(MCCW.date.initial.getFullYear(), month, i).getDay();
+        auxiliary = new Date(year, month, i).getDay();
         if (MCCW.variables.weekday[auxiliary] == MCCW.variables.weekday[0]){
             document.getElementById("calendar").appendChild(elem);
             elem = document.createElement("tr");
@@ -27,7 +28,17 @@ function drawWidgetCalendar(){
     };
 
     function loadCell(data){
-        elem.appendChild(document.createElement("td")).appendChild(document.createTextNode(data));
+        // create td and attach dataset info so we can recognise today/holidays later
+        let td = document.createElement("td");
+        if (data !== ""){
+            td.dataset.day = data;
+            td.dataset.month = month; // zero-based month to match Date.getMonth()
+            td.dataset.year = year;
+            td.appendChild(document.createTextNode(data));
+        } else {
+            td.appendChild(document.createTextNode(""));
+        }
+        elem.appendChild(td);
     };
 
     document.getElementById("calendar").appendChild(elem);
@@ -35,15 +46,71 @@ function drawWidgetCalendar(){
 
 
 function fillWidgetCalendar(){
+    const { currentDay, currentMonth, currentYear } = getCurrentDateInfo();
     let pastDayFlag = true; // Past day flag
-    let days = document.getElementById("calendar").getElementsByTagName("td");
+    const days = document.getElementById("calendar").getElementsByTagName("td");
+    const holidays = collectHolidays(currentYear);
+
     for (let i = 0; i < days.length; i++){
-        if (pastDayFlag){
-            days[i].classList.add("past"); // Add past day class
+        const td = days[i];
+        const dStr = td.dataset.day;
+        if (!dStr){ // skip empty leading/trailing cells
+            continue;
         }
-        if (days[i].innerHTML == MCCW.date.time[2]){
-            days[i].classList.add("today"); // Add today's class
+        const d = Number(dStr);
+        const m = Number(td.dataset.month);
+        const y = Number(td.dataset.year);
+
+        if (pastDayFlag){
+            td.classList.add("past"); // Add past day class
+        }
+        if (d === currentDay && m === currentMonth && y === currentYear){
+            td.classList.add("today"); // Add today's class
             pastDayFlag = false;
         }
+
+        const holiday = findHolidayForDay(holidays, d, m, y);
+        if (holiday) applyHolidayToTd(td, holiday);
     }
+}
+
+function findHolidayForDay(holidays, day, month, year){
+    for (let h of holidays){
+        const hd = Number(h.day);
+        const hm = normalizeHolidayMonth(h.month);
+        const hy = h.year ? Number(h.year) : undefined;
+
+        if (hd === day && hm === month && (hy === undefined || hy === year)){
+            return h;
+        }
+    }
+    return null;
+}
+
+function applyHolidayToTd(td, h){
+    td.classList.add("holiday");
+    if (h.name) td.dataset.tooltip = h.name;  // used by custom CSS tooltip
+}
+
+function getCurrentDateInfo(){
+    return {
+        currentDay: Number(MCCW.date.time && MCCW.date.time[2] ? MCCW.date.time[2] : MCCW.date.initial.getDate()),
+        currentMonth: MCCW.date.initial.getMonth(),
+        currentYear: MCCW.date.initial.getFullYear()
+    };
+}
+
+function collectHolidays(year){
+    let holidays = [];
+    if (typeof publicHoliday === "object" && publicHoliday !== null){
+        if (Array.isArray(publicHoliday[year])) holidays = holidays.concat(publicHoliday[year]);
+        if (Array.isArray(publicHoliday.recurring)) holidays = holidays.concat(publicHoliday.recurring);
+    }
+    return holidays;
+}
+
+function normalizeHolidayMonth(month){
+    let hm = typeof month === "number" ? Number(month) : NaN;
+    if (!isNaN(hm) && hm > 11) hm = hm - 1; // allow 1-12 input
+    return hm;
 }

--- a/project.json
+++ b/project.json
@@ -284,6 +284,15 @@
 				"type" : "bool",
 				"value" : true
 			},
+			"displayPublicHolidays" : 
+			{
+				"condition" : "displayPublicHolidays.value ? displayPublicHolidays.text = displayPublicHolidays.text.replace('Disabled', 'Enabled').replace('ugcDanger','ugcSuccess') : displayPublicHolidays.text = displayPublicHolidays.text.replace('Enabled', 'Disabled').replace('ugcSuccess','ugcDanger')",
+				"index" : 26,
+				"order" : 126,
+				"text" : "Display Public Holidays",
+				"type" : "bool",
+				"value" : true
+			},
 			"displayClock" : 
 			{
 				"condition" : "displayClock.value ? displayClock.text = displayClock.text.replace('Disabled', 'Enabled').replace('ugcDanger','ugcSuccess') : displayClock.text = displayClock.text.replace('Enabled', 'Disabled').replace('ugcSuccess','ugcDanger')",

--- a/properties.js
+++ b/properties.js
@@ -134,6 +134,17 @@ window.wallpaperPropertyListener = {
                 setCSSRootVariable("--calendarDisplay", "none");
             }
         }
+
+        // Toggle showing public holidays in the calendar
+        if (properties.displayPublicHolidays){
+            MCCW.properties.calendar = MCCW.properties.calendar || {};
+            MCCW.properties.calendar.showHolidays = !!properties.displayPublicHolidays.value;
+            // Redraw calendar so the change is applied immediately
+            if (MCCW.widgets && MCCW.widgets.calendar && MCCW.widgets.calendar.draw){
+                MCCW.widgets.calendar.draw();
+                if (MCCW.widgets.calendar.fill) MCCW.widgets.calendar.fill();
+            }
+        }
         if (properties.widget_calendar_x_pos){
             setCSSRootVariable("--calendarLeft", `${properties.widget_calendar_x_pos.value}%`);
         }

--- a/style.css
+++ b/style.css
@@ -452,24 +452,26 @@ body {
     text-underline-offset: 5px;
 }
 
-#calendar td.holiday::after{
-  content: attr(data-tooltip);
+#calendar td.holiday{ position: relative; }
+
+#calendar td.holiday .holiday-tooltip{
+  display: block;
   position: absolute;
   left: 50%;
   transform: translateX(-50%) translateY(-120%);
   white-space: nowrap;
   background: var(--schemeColor);
   color: var(--bgColor);
-  padding: 4px 6px;
-  border-radius: 4px;
-  font-size: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 16px;
   opacity: 0;
   pointer-events: none;
   transition: opacity .12s;
   z-index: 20;
 }
 
-#calendar td.holiday:hover::after{ opacity: 1; }
+#calendar td.holiday:hover .holiday-tooltip{ opacity: 1; }
 
 #calendar.spacing {
     margin-top: 99px;

--- a/style.css
+++ b/style.css
@@ -444,6 +444,33 @@ body {
     text-underline-offset: 5px;
 }
 
+#calendar td.holiday {
+    background-color: var(--schemeColor);
+    color: var(--bgColor);
+    font-weight: bold;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 5px;
+}
+
+#calendar td.holiday::after{
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%) translateY(-120%);
+  white-space: nowrap;
+  background: var(--schemeColor);
+  color: var(--bgColor);
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .12s;
+  z-index: 20;
+}
+
+#calendar td.holiday:hover::after{ opacity: 1; }
+
 #calendar.spacing {
     margin-top: 99px;
 }


### PR DESCRIPTION
# Release Notes — Public Holiday Calendar

Version: v2.0.4 (feature)
Date: 2025-12-26

Summary
- Added public-holiday support to the calendar widget so holidays can be declared in [calendar.js](calendar.js) and displayed on the calendar.

What changed
- New/updated functions in [`js/widgets/calendar.js`](js/widgets/calendar.js):
  - [`collectHolidays`](js/widgets/calendar.js) — merges year-specific, recurring and global holidays.
  - [`findHolidayForDay`](js/widgets/calendar.js) — matches a holiday for a given day.
  - [`applyHolidayToTd`](js/widgets/calendar.js) — marks the cell as a holiday and sets a tooltip via `td.dataset.tooltip`.
  - [`normalizeHolidayMonth`](js/widgets/calendar.js) — accepts both 0-based and 1-12 months (converts >11 to zero-based).
  - [`fillWidgetCalendar`](js/widgets/calendar.js) — now applies holiday highlighting when filling the calendar.
- Holiday data lives in [`calendar.js`](calendar.js) as the `publicHoliday` object (example entries provided).
- Styling: uses the existing tooltip rule in [style.css](style.css) (`#calendar td.holiday::after`) to show holiday names.
- Added `<script type="text/javascript" src="calendar.js"></script>` to `index.html`.


How to use
1. Edit the `publicHoliday` object in [calendar.js](calendar.js). Add holidays under the target year, `recurring`.
2. Reload the wallpaper (or call the calendar draw/fill sequence).
3. Holiday cells will have the `holiday` class and show the holiday name on hover.

Testing checklist
- Add a test entry to `publicHoliday[<year>]` and reload; verify the corresponding day cell has class `holiday`.
- Verify tooltip displays on hover (uses `data-tooltip` and the CSS rule in [style.css](style.css)).
- Verify months entered as 1-12 are normalized correctly by [`normalizeHolidayMonth`](js/widgets/calendar.js).

Notes
- Backwards compatible with existing calendar behavior.
- No external configuration required; everything is local and editable via `calendar.js`.

Files referenced
- [`js/widgets/calendar.js`](js/widgets/calendar.js) — implementation
- [`calendar.js`](calendar.js) — `publicHoliday` sample data
- [`style.css`](style.css) — tooltip styling
- [`index.html`](index.html) — importing

<img width="1850" height="996" alt="image" src="https://github.com/user-attachments/assets/0a78ba4b-1226-4ce6-8848-eb4eb71c11a6" />

