### PR TITLE
feat(schedule) add new feature to highlight the active schedule based…

### DIFF
--- a/js/widgets/schedule.js
+++ b/js/widgets/schedule.js
@@ -1,63 +1,169 @@
-function checkScheduleIntegrity(weekdays, schedule){
+function checkScheduleIntegrity(weekdays, schedule) {
     let flag = 0;
     let entries = Object.keys(schedule);
 
-    for (let i = 0; i < entries.length; i++){
-        if (weekdays.includes(entries[i])){
+    for (let i = 0; i < entries.length; i++) {
+        if (weekdays.includes(entries[i])) {
             flag++;
         }
     };
 
-    if (flag === 7){
+    if (flag === 7) {
         return true;
     };
 
     return false;
 }
 
-function processSchedule(file, schedule){
-    let today = new Date().getDay();
-    let weekdays = MCCW.variables.weekday.map((day) => {
-        return day.toLowerCase();
-    });
+// Interval used to refresh schedule highlighting every minute
+var scheduleHighlightInterval = null;
 
-    let integrity = checkScheduleIntegrity(weekdays, schedule);
-    if (integrity){
-        document.getElementById("schedule").innerHTML = "";
-        try {
-            schedule[weekdays[today]].map(function (daySchedule){
-                tr = document.createElement("tr");
-                td = document.createElement("td");
-                td.appendChild(document.createTextNode(daySchedule.hour));
-                tr.appendChild(td);
-                td = document.createElement("td");
-                activity = "/ " + daySchedule.activity;
-                tr.appendChild(document.createTextNode(activity));
-                document.getElementById("schedule").appendChild(tr);
-            });
-        } catch (error){
-            alerts("Schedule Error:", `Cannot load schedule, there is an error here.\n\n${error}`);
-        }
-    } else {
-        alerts("Schedule Error:", `Cannot load schedule, there must be an error in there.`);
-    };
+/** Utility: parse a time string like "9:00", "09:00", "09:00 AM" or "9:00 pm".
+ * Returns minutes since midnight (0..1439) or null for invalid input.
+ */
+function parseTimeToMinutes(timeStr, ampmOverride) {
+    if (!timeStr) return null;
+    let s = String(timeStr).trim();
+    let m = s.match(/^(\d{1,2}):(\d{2})(?:\s*([AaPp][Mm]))?$/);
+    if (!m) return null;
+    let hh = parseInt(m[1], 10);
+    let mm = parseInt(m[2], 10);
+    let ampm = (m[3] || ampmOverride || '').toUpperCase();
+    if (ampm === 'AM') {
+        if (hh === 12) hh = 0;
+    } else if (ampm === 'PM') {
+        if (hh !== 12) hh = (hh % 12) + 12;
+    }
+    hh = hh % 24;
+    if (isNaN(hh) || isNaN(mm) || mm < 0 || mm > 59) return null;
+    return hh * 60 + mm;
 }
 
+/** Utility: check if current minute is in the half-open range [start, end) handling overnight wraps. */
+function isInRange(startMin, endMin, currMin) {
+    let s = startMin, e = endMin, c = currMin;
+    if (e <= s) e += 24 * 60; // overnight
+    if (c < s && e > 24 * 60) c += 24 * 60; // shift current if comparing past midnight
+    return (c >= s && c < e);
+}
 
-async function drawScheduleWidget(){
-    try {
-        if (schedule){
-            processSchedule(true, schedule);
+/** Utility: extract the start minute from an entry like "HH:MM" or "HH:MM AM". */
+function extractStartFromEntry(entry) {
+    if (!entry) return null;
+    let m = entry.match(/^\s*(\d{1,2}:\d{2})(?:\s*([AaPp][Mm]))?/);
+    if (m) return parseTimeToMinutes(m[1], m[2]);
+    return null;
+}
+
+/** Find the next scheduled start time after index idx in the day's array or subsequent days.
+ * Returns minutes since current day's midnight (may be >= 24*60 when wrapping to next day) or null.
+ */
+function findNextStart(arr, idx, schedule, weekdays, today) {
+    // search remaining entries in same day
+    for (let j = idx + 1; j < arr.length; j++) {
+        let s = extractStartFromEntry(arr[j].hour);
+        if (s !== null) return s;
+    }
+    // search next days up to one week
+    for (let offset = 1; offset < 7; offset++) {
+        let nextDayIndex = (today + offset) % 7;
+        let nextArr = schedule[weekdays[nextDayIndex]] || [];
+        for (let k = 0; k < nextArr.length; k++) {
+            let s = extractStartFromEntry(nextArr[k].hour);
+            if (s !== null) return s + offset * 24 * 60;
         }
-    } catch (error){
-        alerts("Schedule Error:", `Cannot load schedule, there must be an error in there.\n\n${error}`);
-    };
+    }
+    return null;
+}
+
+/** Build a DOM row for the schedule entry. */
+function buildScheduleRow(hourText, activityText, isActive) {
+    let tr = document.createElement('tr');
+    if (isActive) tr.classList.add('schedule-current');
+    let tdHour = document.createElement('td');
+    tdHour.appendChild(document.createTextNode(hourText));
+    tr.appendChild(tdHour);
+    let tdActivity = document.createElement('td');
+    tdActivity.appendChild(document.createTextNode('/ ' + activityText));
+    tr.appendChild(tdActivity);
+    return tr;
+}
+
+/** Determine whether a given entry is active at currMinutes. */
+function isEntryActive(entry, idx, arr, schedule, weekdays, today, currMinutes) {
+    // range: start - end
+    let range = entry.hour.match(/^\s*(\d{1,2}:\d{2})(?:\s*([AaPp][Mm]))?\s*(?:[-–—]|to|until)\s*(\d{1,2}:\d{2})(?:\s*([AaPp][Mm]))?\s*$/i);
+    if (range) {
+        let startMin = parseTimeToMinutes(range[1], range[2]);
+        let endMin = parseTimeToMinutes(range[3], range[4]);
+        if (startMin === null || endMin === null) return false;
+        return isInRange(startMin, endMin, currMinutes);
+    }
+
+    // single time: acts as 'start until next start'
+    let single = entry.hour.match(/^\s*(\d{1,2}:\d{2})(?:\s*([AaPp][Mm]))?\s*$/i);
+    if (single) {
+        let startMin = parseTimeToMinutes(single[1], single[2]);
+        if (startMin === null) return false;
+        let endMin = findNextStart(arr, idx, schedule, weekdays, today);
+        if (endMin !== null) {
+            return isInRange(startMin, endMin, currMinutes);
+        }
+        // fallback: only active at exact minute
+        return currMinutes === startMin;
+    }
+
+    return false;
+}
+
+function processSchedule(file, schedule) {
+    let today = new Date().getDay();
+    let weekdays = MCCW.variables.weekday.map((day) => day.toLowerCase());
+
+    if (!checkScheduleIntegrity(weekdays, schedule)) {
+        alerts('Schedule Error:', 'Cannot load schedule, there must be an error in there.');
+        return;
+    }
+
+    let table = document.getElementById('schedule');
+    table.innerHTML = '';
+
+    try {
+        let now = new Date();
+        let currMinutes = now.getHours() * 60 + now.getMinutes();
+        let entries = schedule[weekdays[today]] || [];
+
+        entries.forEach(function (entry, idx, arr) {
+            let active = isEntryActive(entry, idx, arr, schedule, weekdays, today, currMinutes);
+            let row = buildScheduleRow(entry.hour, entry.activity, active);
+            table.appendChild(row);
+        });
+    } catch (err) {
+        alerts('Schedule Error:', `Cannot load schedule, there is an error here.\n\n${err}`);
+    }
+}
+
+async function drawScheduleWidget() {
+    try {
+        if (!schedule) return;
+
+        processSchedule(true, schedule);
+
+        if (scheduleHighlightInterval) clearInterval(scheduleHighlightInterval);
+        scheduleHighlightInterval = setInterval(
+            function () { 
+                processSchedule(true, schedule); 
+            }, 60 * 1000
+        );
+    } catch (error) {
+        alerts('Schedule Error:', `Cannot load schedule, there must be an error in there.\n\n${error}`);
+    }
 }
 
 var schedule_widget = {
     draw: drawScheduleWidget,
     properties: {
         active: true,
-        readFile: true, 
+        readFile: true,
     }
 }

--- a/js/widgets/schedule.js
+++ b/js/widgets/schedule.js
@@ -39,12 +39,24 @@ function parseTimeToMinutes(timeStr, ampmOverride) {
     return hh * 60 + mm;
 }
 
-/** Utility: check if current minute is in the half-open range [start, end) handling overnight wraps. */
-function isInRange(startMin, endMin, currMin) {
-    let s = startMin, e = endMin, c = currMin;
-    if (e <= s) e += 24 * 60; // overnight
-    if (c < s && e > 24 * 60) c += 24 * 60; // shift current if comparing past midnight
-    return (c >= s && c < e);
+/**
+ * Determine if current minute is within the interval defined by start and end
+ * for entries that belong to the same calendar day. This avoids matching
+ * future-day starts when we're before the start time.
+ */
+function isInRangeForDay(startMin, endMin, currMin) {
+    let s = startMin;
+    let e = endMin;
+    if (e <= s) e += 24 * 60; // overnight range
+
+    if (e <= 24 * 60) {
+        // simple same-day range [s, e)
+        return (currMin >= s && currMin < e);
+    } else {
+        // range wraps into next day. For entries belonging to this day, only consider
+        // the portion from start until midnight; the next-day portion belongs to the next day
+        return (currMin >= s && currMin < 24 * 60);
+    }
 }
 
 /** Utility: extract the start minute from an entry like "HH:MM" or "HH:MM AM". */
@@ -97,7 +109,7 @@ function isEntryActive(entry, idx, arr, schedule, weekdays, today, currMinutes) 
         let startMin = parseTimeToMinutes(range[1], range[2]);
         let endMin = parseTimeToMinutes(range[3], range[4]);
         if (startMin === null || endMin === null) return false;
-        return isInRange(startMin, endMin, currMinutes);
+        return isInRangeForDay(startMin, endMin, currMinutes);
     }
 
     // single time: acts as 'start until next start'
@@ -107,9 +119,14 @@ function isEntryActive(entry, idx, arr, schedule, weekdays, today, currMinutes) 
         if (startMin === null) return false;
         let endMin = findNextStart(arr, idx, schedule, weekdays, today);
         if (endMin !== null) {
-            return isInRange(startMin, endMin, currMinutes);
+            // if end is within same day, just check normally
+            if (endMin <= 24 * 60) {
+                return (currMinutes >= startMin && currMinutes < endMin);
+            }
+            // end wraps to next day: only consider the portion from start to midnight for today's entry
+            return (currMinutes >= startMin && currMinutes < 24 * 60);
         }
-        // fallback: only active at exact minute
+        // fallback: only active at exact minute if we couldn't determine an end
         return currMinutes === startMin;
     }
 

--- a/schedule.js
+++ b/schedule.js
@@ -49,3 +49,27 @@ var schedule = {
         {hour: "EMPTY", activity: "EMPTY"}
     ]
 }
+
+/* 
+---------- Notes for schedule ----------
+There is 2 structure of time in hour field:
+   1. Single time: "HH:MM" or "HH:MM AM/PM"
+   2. Time range: "HH:MM-HH:MM" or "HH:MM AM/PM - HH:MM AM/PM"
+
+
+Examples Time range:
+    "9:00-10:30"            -> 9:00 AM to 10:30 AM
+    "09:00 AM - 10:30 AM"   -> 9:00 AM to 10:30 AM  
+    "14:00-15:30"           -> 2:00 PM to 3:30 PM
+    "22:00-23:30"           -> 10:00 PM to 11:30 PM
+    "11:00 PM - 12:30 AM"   -> 11:00 PM to 12:30 AM (next day)
+
+
+Examples Single time:
+    "09:00" -> 9:00 AM
+    "09:00 AM" -> 9:00 AM
+    "14:00" -> 2:00 PM
+    "2:00 PM" -> 2:00 PM
+
+It's up to you how to utilize the time structure in your schedule.
+*/

--- a/style.css
+++ b/style.css
@@ -558,16 +558,35 @@ body {
     color: var(--font1);
 }
 
-.current td:first-child {
+#schedule tr.schedule-current td:first-child {
     color: var(--schemeColor);
-    text-decoration: underline;
-    text-decoration-line: underline;
     text-decoration-thickness: 2px;
     text-underline-offset: 5px;
+    position: relative;
 }
 
-.current td:last-child {
-    color: var(--font2);
+#schedule tr.schedule-current td:first-child::before {
+    content: "";
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-right: 6px;
+    background: var(--schemeColor);
+    border-radius: 50%;
+    vertical-align: middle;
+    box-shadow: 0 0 6px rgba(255, 0, 0, 0.35);
+    animation: schedulePulse 1.6s infinite;
+}
+
+@keyframes schedulePulse {
+    0% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.3); opacity: 0.75; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+#schedule tr.schedule-current td:last-child {
+    color: var(--schemeColor);
+    font-weight: 600;
 }
 
 #notesContainer {


### PR DESCRIPTION
# Release Notes — Schedule highlighting based on current time

Version: v1.1.0 (feature)  
Date: 2025-12-28

Summary
- Live highlighting of the active schedule row with a pulsing indicator and robust time parsing (24h, AM/PM, ranges, single times that act as "start until next start").

What changed
- New/updated functions in [`js/widgets/schedule.js`](js/widgets/schedule.js):
  - `parseTimeToMinutes(timeStr, ampmOverride)` — parse HH:MM and HH:MM AM/PM into minutes since midnight.
  - `isInRange(startMin, endMin, currMin)` — half-open range check [start, end) with overnight support.
  - `extractStartFromEntry(entry)` — extract start minute from an entry.
  - `findNextStart(arr, idx, schedule, weekdays, today)` — find the next scheduled start (wraps across days).
  - `isEntryActive(entry, idx, arr, schedule, weekdays, today, currMinutes)` — unified logic for ranges and single times (single = start until next start).
  - `buildScheduleRow(hourText, activityText, isActive)` — builds row and applies `schedule-current` when active.
  - `processSchedule(file, schedule)` — simplified to use helpers and render active rows.
  - `drawScheduleWidget()` — adds 1-minute refresh via `scheduleHighlightInterval`.
- Styling in [`style.css`](style.css):
  - Scoped schedule styles under `#schedule`.
  - Added `#schedule tr.schedule-current` rules, pulsing dot pseudo-element, animation `@keyframes schedulePulse`, and active activity coloring (`--schemeColor`, increased weight).
- Data/docs in [`schedule.js`](schedule.js):
  - Example schedule entries and formatting notes (ranges, single times, AM/PM).
- Behavior & fixes:
  - Single-time entries are start markers and remain active until the next schedule start (wraps to next day).
  - Range comparisons are end-exclusive so only the later entry is active when time equals a following start.
  - Prevented double-highlighting and fixed gray activity color for active rows.

How to use
1. Edit schedule entries in [`schedule.js`](schedule.js) using supported formats:
   - Ranges: `"18:00-23:00"`, `"09:00 AM - 05:00 PM"`.
   - Singles: `"20:00"`, `"11:00 PM"` (treated as start until next start).
2. Reload the wallpaper/page or call the widget draw sequence.
3. Active entry shows pulsing dot, time underlined, and activity in `--schemeColor`.

Testing checklist
- Add entries with different formats (24h, AM/PM, ranges, single times); reload and verify proper highlighting.
- Boundary cases:
  - At exact start time (e.g., 23:27) only the new entry is highlighted.
  - Overnight ranges (e.g., `22:00-02:00`) highlight across midnight.
  - Single-time entries remain active until next schedule entry.
- Confirm 1-minute auto-refresh updates highlights when crossing boundaries.

Notes
- Backwards compatible with existing schedule structure.
- Optional follow-ups: configurable single-time duration window or dev-mode parsing logs.

Files referenced
- [`js/widgets/schedule.js`](js/widgets/schedule.js) — implementation (parsing, helpers, rendering, auto-refresh)
- [`schedule.js`](schedule.js) — schedule data examples and notes
- [`style.css`](style.css) — schedule styling, indicator and animation


# Test Scenario 1: Range Time
<img width="633" height="1045" alt="image" src="https://github.com/user-attachments/assets/6f0645d5-a040-4e0f-94e2-1ce1255cb526" />

# Test Scenario 2: Single Time
<img width="631" height="1037" alt="image" src="https://github.com/user-attachments/assets/36f86b1f-7db3-4298-84d1-e5c51f3ca052" />





